### PR TITLE
elevator send failure response if it cannot handle a request

### DIFF
--- a/ElevatorSim/src/elevatorsim/elevator/ElevatorServer.java
+++ b/ElevatorSim/src/elevatorsim/elevator/ElevatorServer.java
@@ -64,8 +64,9 @@ public class ElevatorServer extends UDPServer {
 			} catch (UnknownHostException e) {
 				e.printStackTrace();
 			}
+			return MessagePackets.Responses.RESPONSE_SUCCESS();
 		}
-		return MessagePackets.Responses.RESPONSE_SUCCESS();
+		return MessagePackets.Responses.RESPONSE_FAILURE();
 	}
 	
 	/**


### PR DESCRIPTION
If an elevator isn't ready for a elevator request it will send a failure response instead of success