### PR TITLE
Fix bug where FloorEvent thread ends prematurely

### DIFF
--- a/ElevatorSim/src/elevatorsim/floor/FloorEvents.java
+++ b/ElevatorSim/src/elevatorsim/floor/FloorEvents.java
@@ -33,7 +33,7 @@ public class FloorEvents extends Thread implements MessageReciever {
 			this.server = new FloorServer(this);
 			server.startServer();
 			Thread.sleep(NetworkConstants.DELAY_SERVER_START_MS);
-			while(running) {
+			while(running || !eventQueue.isEmpty()) {
 				processEvents();
 				Thread.sleep(500);
 			}


### PR DESCRIPTION
This bug fix is not important unless we also want to merge scheduler_notify_floor